### PR TITLE
Add the @lockdown-systems/ringrtc fork to singleArchFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,7 +454,7 @@
         }
       },
       "sign": "./ts/scripts/sign-macos.node.js",
-      "singleArchFiles": "node_modules/@signalapp/{libsignal-client/prebuilds/**,ringrtc/build/**,sqlcipher/prebuilds/**}",
+      "singleArchFiles": "node_modules/@signalapp/{libsignal-client/prebuilds/**,sqlcipher/prebuilds/**},node_modules/@lockdown-systems/ringrtc/build/**",
       "target": [
         {
           "target": "zip",


### PR DESCRIPTION
This is required for Mac releases.