### PR TITLE
Fix macOS packaging issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,15 +454,8 @@
         }
       },
       "sign": "./ts/scripts/sign-macos.node.js",
-      "singleArchFiles": "node_modules/@signalapp/{libsignal-client/prebuilds/**,sqlcipher/prebuilds/**},node_modules/@lockdown-systems/ringrtc/build/**",
+      "singleArchFiles": "{node_modules/@signalapp/libsignal-client/prebuilds/**,node_modules/@signalapp/sqlcipher/prebuilds/**,node_modules/@lockdown-systems/ringrtc/build/**}",
       "target": [
-        {
-          "target": "zip",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
-        },
         {
           "target": "dmg",
           "arch": [


### PR DESCRIPTION
Fixes #30.

This updates `singleArchFile` to successfully build in macOS. It also only targets universal2 dmg, which greatly speeds up the build.